### PR TITLE
Enable http caching and offline runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .vscode
 .env
+.scrapy

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 A web scraper for collecting data from [Transfermarkt](https://www.transfermarkt.co.uk/) website. It recurses into the Transfermarkt hierarchy to find leagues, clubs, players and [appearances satistics](https://www.transfermarkt.co.uk/diogo-jota/leistungsdatendetails/spieler/340950/saison/2020/verein/0/liga/0/wettbewerb/GB1/pos/0/trainer_id/0/plus/1), and extracts them as JSON objects. 
 
-
-`(root) |> Confederations |> Leagues |> Clubs |> (Players, Games) |> Appearances`
+```console
+(root) |> Confederations |> Leagues |> Clubs |> (Players, Games) |> Appearances
+```
 
 The scraper can be used to discover and refresh each one of these entities separately.
 

--- a/tfmkt/settings.py
+++ b/tfmkt/settings.py
@@ -18,7 +18,15 @@ FEED_URI = 'stdout:'
 EXTENSIONS = {
    'scrapy.extensions.closespider.CloseSpider': 500
 }
+DOWNLOADER_MIDDLEWARES = {
+   'scrapy.downloadermiddlewares.httpcache.HttpCacheMiddleware': 500
+}
 
 CLOSESPIDER_PAGECOUNT = 0
 
 LOG_LEVEL = 'ERROR'
+
+# HttpCacheMiddleware settings
+# See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
+HTTPCACHE_ENABLED = True
+HTTPCACHE_DIR = 'httpcache'


### PR DESCRIPTION
It enables http local caching by default. Http requests and responses are saved at `.scrapy/httpcache`. After that, subsequent runs hit the cache instead of the remote server.

Use `HttpCacheMiddleware` settings to toggle cache support on an off

Closes #13 