### PR TITLE
Add games crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is a [scrapy](https://scrapy.org/) project, so it needs to be run with the
 for the necessary environment to run the scraper.
 
 ```console
-# create the conda environment with "conda env create -f environment.yml"
+# create the conda environment with (`conda env create -f environment.yml`)
 conda activate transfermarkt-scraper
 
 # discover confederantions and leagues on separate invokations

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is a [scrapy](https://scrapy.org/) project, so it needs to be run with the
 for the necessary environment to run the scraper.
 
 ```console
-# create the conda environment with (`conda env create -f environment.yml`)
+# create the conda environment (conda env create -f environment.yml)
 conda activate transfermarkt-scraper
 
 # discover confederantions and leagues on separate invokations

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ This is a [scrapy](https://scrapy.org/) project, so it needs to be run with the
 for the necessary environment to run the scraper.
 
 ```console
-# conda env create -f environment.yml
-# conda activate transfermarkt-scraper
+# create the conda environment with "conda env create -f environment.yml"
+conda activate transfermarkt-scraper
 
 # discover confederantions and leagues on separate invokations
 scrapy crawl confederations > confederations.json
 scrapy crawl leagues -a parents=confederations.json > leagues.json
 
-# you can use the intermediate files or pipe crawlers one after the other to traverse hierarchy 
+# you can use intermediate files or pipe crawlers one after the other to traverse hierarchy 
 cat leagues | head -2 \
     | scrapy crawl clubs \
     | scrapy crawl players \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This is a [scrapy](https://scrapy.org/) project, so it needs to be run with the
 for the necessary environment to run the scraper.
 
 ```console
-# create the conda environment (conda env create -f environment.yml)
+# create and activate conda environment
+conda env create -f environment.yml
 conda activate transfermarkt-scraper
 
 # discover confederantions and leagues on separate invokations

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 A web scraper for collecting data from [Transfermarkt](https://www.transfermarkt.co.uk/) website. It recurses into the Transfermarkt hierarchy to find leagues, clubs, players and [appearances satistics](https://www.transfermarkt.co.uk/diogo-jota/leistungsdatendetails/spieler/340950/saison/2020/verein/0/liga/0/wettbewerb/GB1/pos/0/trainer_id/0/plus/1), and extracts them as JSON objects. 
 
 ```console
-(root) |> Confederations |> Leagues |> Clubs |> (Players, Games) |> Appearances
+(root) |> Confederations |> Leagues |> Clubs |> Players |> Appearances
+                                    |> Games
 ```
 
 The scraper can be used to discover and refresh each one of these entities separately.

--- a/README.md
+++ b/README.md
@@ -3,14 +3,18 @@
 ![docker build status](https://github.com/dcaribou/transfermarkt-scraper/workflows/Dockerhub%20Image/badge.svg)
 # transfermarkt-scraper
 
-A web scraper for collecting data from [Transfermarkt](https://www.transfermarkt.co.uk/) website. It recurses into the Transfermarkt hierarchy to find leagues, clubs, players and [appearances satistics](https://www.transfermarkt.co.uk/diogo-jota/leistungsdatendetails/spieler/340950/saison/2020/verein/0/liga/0/wettbewerb/GB1/pos/0/trainer_id/0/plus/1), and extracts them as JSON objects. 
+A web scraper for collecting data from [Transfermarkt](https://www.transfermarkt.co.uk/) website. It recurses into the Transfermarkt hierarchy to find
+[leagues](https://www.transfermarkt.co.uk/wettbewerbe/europa), 
+[games](https://www.transfermarkt.co.uk/premier-league/gesamtspielplan/wettbewerb/GB1/saison_id/2020),
+[clubs](https://www.transfermarkt.co.uk/premier-league/startseite/wettbewerb/GB1),
+[players](https://www.transfermarkt.co.uk/manchester-city/kader/verein/281/saison_id/2019) and [appearances](https://www.transfermarkt.co.uk/sergio-aguero/leistungsdaten/spieler/26399), and extract them as JSON objects. 
 
 ```console
 (root) |> Confederations |> Leagues |> Clubs |> Players |> Appearances
                                     |> Games
 ```
 
-The scraper can be used to discover and refresh each one of these entities separately.
+Each one of these entities can be discovered and refresh separately by invoking the corresponding crawler.
 
 ## run
 This is a [scrapy](https://scrapy.org/) project, so it needs to be run with the
@@ -21,9 +25,11 @@ for the necessary environment to run the scraper.
 # conda env create -f environment.yml
 # conda activate transfermarkt-scraper
 
+# discover confederantions and leagues on separate invokations
 scrapy crawl confederations > confederations.json
 scrapy crawl leagues -a parents=confederations.json > leagues.json
 
+# you can use the intermediate files or pipe crawlers one after the other to traverse hierarchy 
 cat leagues | head -2 \
     | scrapy crawl clubs \
     | scrapy crawl players \

--- a/tfmkt/spiders/spiders.py
+++ b/tfmkt/spiders/spiders.py
@@ -88,6 +88,80 @@ class LeaguesSpider(BaseSpider):
       url = match.getall()[0]
       yield {'type': 'league', 'href': url, 'parent': parent}
 
+class GamesSpider(BaseSpider):
+  name = 'games'
+
+  def parse(self, response, parent):
+    """Parse leagues page. From this page follow to the games and fixutres page.
+
+    @url https://www.transfermarkt.co.uk/premier-league/startseite/wettbewerb/GB1
+    @returns requests 1 1
+    @cb_kwargs {"parent": "dummy"}
+    @scrapes type href parent
+    """
+
+    footer_links = response.css('div.footer-links')
+    for footer_link in footer_links:
+      text = footer_link.xpath('a//text()').get()
+      if text == "All fixtures & results":
+        next_url = footer_link.xpath('a/@href').get()
+
+        cb_kwargs = {
+            'base' : {
+              'parent': parent
+            }
+          }
+
+        return response.follow(next_url, self.extract_game_urls, cb_kwargs=cb_kwargs)
+
+  def extract_game_urls(self, response, base):
+    """Parse games and fixutres page. From this page follow to each game page.
+
+    @url https://www.transfermarkt.co.uk/premier-league/gesamtspielplan/wettbewerb/GB1/saison_id/2020
+    @returns requests 330 390
+    @cb_kwargs {"base": {"href": "some_href", "type": "league", "parent": {}}}
+    @scrapes type href parent game_id 
+    """
+
+    game_links = response.css('a.ergebnis-link')
+    for game_link in game_links:
+      href = game_link.xpath('@href').get()
+
+      cb_kwargs = {
+        'base': {
+          'parent': base['parent'],
+          'href': href
+        }
+      }
+
+      yield response.follow(href, self.parse_game, cb_kwargs=cb_kwargs)
+
+  def parse_game(self, response, base):
+    """Parse games and fixutres page. From this page follow to each game page.
+
+    @url https://www.transfermarkt.co.uk/caykur-rizespor_fenerbahce-sk/index/spielbericht/3426662
+    @returns items 1 1
+    @cb_kwargs {"base": {"href": "some_href/3", "type": "league", "parent": {}}}
+    @scrapes type href parent game_id result matchday date
+    """
+
+    result = response.css('div.sb-endstand::text').get().strip()
+    date_attributes = response.css('p.sb-datum').xpath('a/text()')
+    matchday = date_attributes[0].get().strip()
+    date = date_attributes[1].get().strip()
+    game_id = int(base['href'].split('/')[-1])
+
+    item = {
+      **base,
+      'type': 'game',
+      'game_id': game_id,
+      'result': result,
+      'matchday': matchday,
+      'date': date
+    }
+    
+    yield item
+
 class ClubsSpider(BaseSpider):
   name = 'clubs'
 


### PR DESCRIPTION
Extracting games is not yet supported

(root) |> Confederations |> Leagues |> Clubs |> (Players, Games) |> Appearances

Implement a new spider that extracts games. The parent entities may be Clubs or Leagues, though Clubs seem more appropriate as Leagues only contain national competitions.

Closes #11 