### PR TITLE
Support "seasoned" runs 

### DIFF
--- a/tfmkt/settings.py
+++ b/tfmkt/settings.py
@@ -7,6 +7,8 @@ NEWSPIDER_MODULE = 'tfmkt.spiders'
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 USER_AGENT = 'transfermarkt-scraper (https://github.com/dcaribou/transfermarkt-scraper)'
 
+SEASON = 2020
+
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 

--- a/tfmkt/settings.py
+++ b/tfmkt/settings.py
@@ -7,6 +7,7 @@ NEWSPIDER_MODULE = 'tfmkt.spiders'
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 USER_AGENT = 'transfermarkt-scraper (https://github.com/dcaribou/transfermarkt-scraper)'
 
+# Default season to scrape
 SEASON = 2020
 
 # Obey robots.txt rules

--- a/tfmkt/spiders/spiders.py
+++ b/tfmkt/spiders/spiders.py
@@ -57,7 +57,7 @@ class BaseSpider(scrapy.Spider):
       elif item['type'] in ['league']:
         item['seasoned_href'] = f"{self.base_url}{item['href']}/plus/0?saison_id={season}"
       else:
-        item['seasoned_href'] = item['href']
+        item['seasoned_href'] = f"{self.base_url}{item['href']}"
 
     return [
       Request(
@@ -302,8 +302,12 @@ class AppearancesSpider(BaseSpider):
     @cb_kwargs {"parent": "dummy"}
     """
 
+    season = self.settings['SEASON']
+
     full_stats_href = response.xpath('//a[contains(text(),"View full stats")]/@href').get()
-    yield response.follow(full_stats_href, self.parse_stats, cb_kwargs={'parent': parent})
+    seasoned_full_stats_href = full_stats_href + f"/plus/0?saison={season}"
+
+    yield response.follow(seasoned_full_stats_href, self.parse_stats, cb_kwargs={'parent': parent})
 
   def parse_stats(self, response, parent):
     """Parse player's full stats. From this page we collect all player appearances
@@ -329,8 +333,8 @@ class AppearancesSpider(BaseSpider):
         ]
 
         for value_elements in value_elements_matrix:
-            assert(len(header_elements) == len(value_elements))
-            yield dict(zip(header_elements, value_elements))
+          assert(len(header_elements) == len(value_elements))
+          yield dict(zip(header_elements, value_elements))
 
     def parse_stats_elem(elem):
         """Parse an individual table cell"""


### PR DESCRIPTION
Relates to #18

Allow pinning the scraper run to a specific season

"Seasonized" URLs are appending
* Leagues: `plus/0?saison_id={season}`
* Clubs: `saison_id/{season}`
* Players `saison_id/{season}`