### PR TITLE
Use scrapy default user agent

### DIFF
--- a/.github/workflows/scrapy-checks.yml
+++ b/.github/workflows/scrapy-checks.yml
@@ -35,4 +35,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Check scrapy contracts
       run: |
-        scrapy check
+        scrapy check -s USER_AGENT='scrapy checks'

--- a/.github/workflows/scrapy-checks.yml
+++ b/.github/workflows/scrapy-checks.yml
@@ -35,4 +35,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Check scrapy contracts
       run: |
-        scrapy check -s USER_AGENT='scrapy checks'
+        scrapy check -s USER_AGENT='transfermarkt scrapy contracts'

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ A web scraper for collecting data from [Transfermarkt](https://www.transfermarkt
 [players](https://www.transfermarkt.co.uk/manchester-city/kader/verein/281/saison_id/2019) and [appearances](https://www.transfermarkt.co.uk/sergio-aguero/leistungsdaten/spieler/26399), and extract them as JSON objects. 
 
 ```console
-Confederations   ==>   Leagues   ==>   Clubs   ==>   Players   ==>   Appearances
-                                 ==>   Games
+Confederations ====> Leagues ====> (Clubs, Games) ====> Players ====> Appearances
 ```
 
 Each one of these entities can be discovered and refresh separately by invoking the corresponding crawler.
@@ -45,8 +44,7 @@ docker run \
     dcaribou/transfermarkt-scraper:main \
     scrapy crawl leagues -a parents=samples/confederations.json
 ```
-> :warning: When using this scraper please identify your project accordingly by using a custom user agent. You can pass the user agent string to the scraper by using the `USER_AGENT` scrapy setting
-> For example `scrapy crawl players -s USER_AGENT=<your user agent> `
+> :warning: When using this scraper please identify your project accordingly by using a custom user agent. You can pass the user agent string using the `USER_AGENT` scrapy setting. For example, `scrapy crawl players -s USER_AGENT=<your user agent> `
  
 Items are extracted in JSON format with one JSON object per item (confederation, league, club, player or appearance), which gets printed to the `stdout`. Samples of extracted data are provided in the [samples](samples) folder.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A web scraper for collecting data from [Transfermarkt](https://www.transfermarkt
 [players](https://www.transfermarkt.co.uk/manchester-city/kader/verein/281/saison_id/2019) and [appearances](https://www.transfermarkt.co.uk/sergio-aguero/leistungsdaten/spieler/26399), and extract them as JSON objects. 
 
 ```console
-Confederations ====> Leagues ====> (Clubs, Games) ====> Players ====> Appearances
+====> Confederations ====> Leagues ====> (Clubs, Games) ====> Players ====> Appearances
 ```
 
 Each one of these entities can be discovered and refresh separately by invoking the corresponding crawler.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A web scraper for collecting data from [Transfermarkt](https://www.transfermarkt
 [players](https://www.transfermarkt.co.uk/manchester-city/kader/verein/281/saison_id/2019) and [appearances](https://www.transfermarkt.co.uk/sergio-aguero/leistungsdaten/spieler/26399), and extract them as JSON objects. 
 
 ```console
-(root) |> Confederations |> Leagues |> Clubs |> Players |> Appearances
-                                    |> Games
+Confederations   ==>   Leagues   ==>   Clubs   ==>   Players   ==>   Appearances
+                                 ==>   Games
 ```
 
 Each one of these entities can be discovered and refresh separately by invoking the corresponding crawler.
@@ -36,6 +36,7 @@ cat leagues | head -2 \
     | scrapy crawl players \
     | scrapy crawl appearances
 ```
+
 Alternatively you can also use [`dcaribou/transfermarkt-scraper`](https://hub.docker.com/repository/docker/dcaribou/transfermarkt-scraper) docker image
 
 ```console
@@ -44,6 +45,9 @@ docker run \
     dcaribou/transfermarkt-scraper:main \
     scrapy crawl leagues -a parents=samples/confederations.json
 ```
+> :warning: When using this scraper please identify your project accordingly by using a custom user agent. You can pass the user agent string to the scraper by using the `USER_AGENT` scrapy setting
+> For example `scrapy crawl players -s USER_AGENT=<your user agent> `
+ 
 Items are extracted in JSON format with one JSON object per item (confederation, league, club, player or appearance), which gets printed to the `stdout`. Samples of extracted data are provided in the [samples](samples) folder.
 
 Check out [player-scores](https://github.com/dcaribou/player-scores) to see `transfermarkt-scraper` in action on a real analytics project.

--- a/tfmkt/settings.py
+++ b/tfmkt/settings.py
@@ -4,8 +4,6 @@ BOT_NAME = 'tfmkt'
 SPIDER_MODULES = ['tfmkt.spiders']
 NEWSPIDER_MODULE = 'tfmkt.spiders'
 
-# Crawl responsibly by identifying yourself (and your website) on the user-agent
-USER_AGENT = 'transfermarkt-scraper (https://github.com/dcaribou/transfermarkt-scraper)'
 
 # Default season to scrape
 SEASON = 2020

--- a/tfmkt/spiders/spiders.py
+++ b/tfmkt/spiders/spiders.py
@@ -355,7 +355,7 @@ class AppearancesSpider(BaseSpider):
         result_href = elem.css('a.ergebnis-link::attr(href)').get()
 
         if (
-            (has_classification_in_brackets and club_href is not None and not has_shield_class) or
+            (has_classification_in_brackets and club_href is None) or
             (club_href is not None and not has_shield_class) 
             ):
           return None


### PR DESCRIPTION
* Update default settings to use scrapy user agent by default.
* Advice potential scraper users to identify their project accordingly with a custom user agent.