### PR TITLE
Adapt to Transfermakt site upstream changes

### DIFF
--- a/tfmkt/spiders/appearances.py
+++ b/tfmkt/spiders/appearances.py
@@ -68,7 +68,6 @@ class AppearancesSpider(BaseSpider):
         # club information is parsed from team "shields" using a separate logic from the rest
         # identify cells containing club shields
         has_shield_class = elem.css('img::attr(src)').get() is not None
-        # club_href = elem.css('a.vereinprofil_tooltip::attr(href)').get()
         club_href = elem.xpath('tm-tooltip[@data-type="club"]/a/@href').get()
         result_href = elem.css('a.ergebnis-link::attr(href)').get()
         

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -1,7 +1,5 @@
 from tfmkt.spiders.common import BaseSpider
 from scrapy.shell import inspect_response # required for debugging
-import re
-from inflection import parameterize, underscore
 
 class PlayersSpider(BaseSpider):
   name = 'players'
@@ -14,13 +12,17 @@ class PlayersSpider(BaseSpider):
         @cb_kwargs {"parent": "dummy"}
       """
 
-      player_hrefs = response.css(
-            'a.spielprofil_tooltip::attr(href)'
-        ).getall()
+      # inspect_response(response, self)
+      # exit(1)
 
-      without_duplicates = list(set(player_hrefs))
+      players_table = response.xpath("//div[@class='responsive-table']")
+      assert len(players_table) == 1
 
-      for href in without_duplicates:
+      players_table = players_table[0]
+
+      player_hrefs = players_table.xpath("//tm-tooltip[@data-type='player']/div[1]/span/a/@href").getall()
+
+      for href in player_hrefs:
           
           cb_kwargs = {
             'base' : {


### PR DESCRIPTION
Closes #34 

There were two changes in Transfermarkt that affected the scraper:

* Competition table headers (responsive tables) queries do not longer collision with the Stats table, hence we needed to remove the filter for that table
* The indentifier for a game/club/player type node is no longer by using the vereinprofil_tooltip class. Instead, use data-type="club"