### PR TITLE
Adapt to Transfermakt site upstream changes

### DIFF
--- a/tfmkt/spiders/appearances.py
+++ b/tfmkt/spiders/appearances.py
@@ -68,7 +68,7 @@ class AppearancesSpider(BaseSpider):
         # club information is parsed from team "shields" using a separate logic from the rest
         # identify cells containing club shields
         has_shield_class = elem.css('img::attr(src)').get() is not None
-        club_href = elem.xpath('tm-tooltip[@data-type="club"]/a/@href').get()
+        club_href = elem.xpath('a[contains(@href, "spielplan/verein")]/@href').get()
         result_href = elem.css('a.ergebnis-link::attr(href)').get()
         
         self.logger.debug("Extracted values: has_shield_class: %s, club_href: %s, result_href: %s", has_shield_class, club_href, result_href)

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -20,7 +20,7 @@ class PlayersSpider(BaseSpider):
 
       players_table = players_table[0]
 
-      player_hrefs = players_table.xpath("//tm-tooltip[@data-type='player']/div[1]/span/a/@href").getall()
+      player_hrefs = players_table.xpath('//table[@class="inline-table"]/tr[1]/td[2]/div[1]/span/a/@href').getall()
 
       for href in player_hrefs:
           


### PR DESCRIPTION
The indentifier for a game/club/player type node `data-type="club"` has been remove, and we need to rely now in the href contents