### PR TITLE
Scrape player historical market value

### DIFF
--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -41,7 +41,7 @@ class PlayersSpider(BaseSpider):
     """Extract player details from the main page.
     It currently only parses the PLAYER DATA section.
 
-      @url https://www.transfermarkt.co.uk/harvey-davies/profil/spieler/706815
+      @url https://www.transfermarkt.co.uk/steven-berghuis/profil/spieler/129554
       @returns items 1 1
       @cb_kwargs {"base": {"href": "some_href", "type": "player", "parent": {}}}
       @scrapes href type parent

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -1,5 +1,7 @@
 from tfmkt.spiders.common import BaseSpider
 from scrapy.shell import inspect_response # required for debugging
+import re
+import json
 
 class PlayersSpider(BaseSpider):
   name = 'players'
@@ -90,6 +92,20 @@ class PlayersSpider(BaseSpider):
         attributes['social_media'].append(
           href
         )
+
+    # parse historical market value
+    pattern = re.compile('\'data\'\:.*\}\}]')
+
+    d = (
+        json
+        .loads('{' + response.xpath("//script[contains(., 'series')]/text()").re(pattern)[0].replace("\'", "\"").encode().decode('unicode_escape') + '}')
+    )
+
+    for x in d['data']:
+        x['date_x'] = x.pop('x')
+        x['market_value'] = x.pop('y')
+
+    attributes['market_value_history'] = d
 
     yield {
       **base,


### PR DESCRIPTION
It adds functionality for scraping player historical market value.

<img width="685" alt="image" src="https://user-images.githubusercontent.com/16071835/162490475-763d59d7-9138-40d6-83cd-6cfcbd0470dc.png">

It uses some smartness created by @lukesonnet to get market valuation from the "Market value" graph in the "PLAYER DATA" section. Again, thanks a lot for this Luke.