### PR TITLE
Update pythong for M1 and fix table row selector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 
 WORKDIR /app
 

--- a/tfmkt/spiders/competitions.py
+++ b/tfmkt/spiders/competitions.py
@@ -25,7 +25,7 @@ class CompetitionsSpider(BaseSpider):
     # inspect_response(response, self)
     # exit(1)
 
-    table_rows = response.css('table.items tbody').xpath('tr')
+    table_rows = response.css('table.items tbody tr.odd, table.items tbody tr.even')
 
     for row in table_rows[1:]:
       country_image_url = row.xpath('td')[1].css('img::attr(src)').get()
@@ -58,7 +58,7 @@ class CompetitionsSpider(BaseSpider):
     """Parse competitions from the country competitions page.
 
     @url https://www.transfermarkt.co.uk/wettbewerbe/national/wettbewerbe/157
-    @returns items 3 3
+    @returns items 2 2
     @cb_kwargs {"base": {"href": "some_href/3", "type": "competition", "parent": {}, "country_id": 1, "country_name": "n", "country_code": "CC"}}
     @scrapes type href parent country_id country_name country_code competition_type
     """

--- a/tfmkt/spiders/competitions.py
+++ b/tfmkt/spiders/competitions.py
@@ -27,7 +27,7 @@ class CompetitionsSpider(BaseSpider):
 
     table_rows = response.css('table.items tbody tr.odd, table.items tbody tr.even')
 
-    for row in table_rows[1:]:
+    for row in table_rows[0:]:
       country_image_url = row.xpath('td')[1].css('img::attr(src)').get()
       country_name = row.xpath('td')[1].css('img::attr(title)').get()
       country_code = (
@@ -58,7 +58,7 @@ class CompetitionsSpider(BaseSpider):
     """Parse competitions from the country competitions page.
 
     @url https://www.transfermarkt.co.uk/wettbewerbe/national/wettbewerbe/157
-    @returns items 2 2
+    @returns items 3 3
     @cb_kwargs {"base": {"href": "some_href/3", "type": "competition", "parent": {}, "country_id": 1, "country_name": "n", "country_code": "CC"}}
     @scrapes type href parent country_id country_name country_code competition_type
     """


### PR DESCRIPTION
older python was giving me issues on Apple M1 macbook and competition selector failed on table header (i think it was african league)