### PR TITLE
Update game events

### DIFF
--- a/tfmkt/spiders/games.py
+++ b/tfmkt/spiders/games.py
@@ -170,7 +170,8 @@ class GamesSpider(BaseSpider):
 
     game_events = (
       self.extract_game_events(response, event_type="Goals") +
-      self.extract_game_events(response, event_type="Substitutions")
+      self.extract_game_events(response, event_type="Substitutions") +
+      self.extract_game_events(response, event_type="Cards")
     )
 
     item = {

--- a/tfmkt/spiders/games.py
+++ b/tfmkt/spiders/games.py
@@ -104,7 +104,9 @@ class GamesSpider(BaseSpider):
           e.xpath("./div[@class = 'sb-aktion-spielstand']/b/text()").get()
         ),
         "description": self.safe_strip(
-          action_element.xpath("./text()").getall()[1]
+          # goal/card or substitution description
+          (" ".join([s.strip() for s in action_element.xpath("./text()").getall()])).strip() 
+            or (" ".join(action_element.xpath(".//span[@class = 'sb-aktion-wechsel-aus']/span/text()").getall())).strip()
         ),
         "player_in": {
           "href": action_element.xpath(".//div/a/@href").get()

--- a/tfmkt/spiders/games.py
+++ b/tfmkt/spiders/games.py
@@ -110,6 +110,9 @@ class GamesSpider(BaseSpider):
         ),
         "player_in": {
           "href": action_element.xpath(".//div/a/@href").get()
+        },
+        "player_assist": {
+          "href": action_element.xpath("./a/@href").getall()[1] if len(action_element.xpath("./a/@href").getall()) > 1 else None
         }
       }
       events.append(event)


### PR DESCRIPTION
Update game events:
1.  add cards event
2.  extract description of card and substitution.  such as `8. Yellow card , Foul` for card or `Injury` for subsitiution.
3. add assisted player(if make this change should also add `player_assist_id`  for `transfermarkt_datasets` in `base_game_events.sql` and `game_events.sql`)

https://www.transfermarkt.co.uk/austin-fc_los-angeles-galaxy/index/spielbericht/3996407