### PR TITLE
Create spider for player transfers

### DIFF
--- a/tfmkt/spiders/transfers.py
+++ b/tfmkt/spiders/transfers.py
@@ -1,0 +1,54 @@
+from tfmkt.spiders.common import BaseSpider
+from scrapy.shell import inspect_response
+import re
+import json
+
+
+class PlayerTransfersSpider(BaseSpider):
+    name = 'transfers'
+
+    def parse(self, response, parent):
+        """Parse player's page to collect transfer history URL.
+
+        @url https://www.transfermarkt.co.uk/ayoze-perez/profil/spieler/246968
+        @returns requests 1 1
+        @cb_kwargs {"parent": "dummy"}
+        """
+        player_id = response.url.split('/')[-1]
+        transfers_api_url = f"/ceapi/transferHistory/list/{player_id}"
+
+        cb_kwargs = {
+            'parent': parent
+        }
+
+        yield response.follow(transfers_api_url, self.parse_transfers, cb_kwargs=cb_kwargs)
+
+    def parse_transfers(self, response, parent):
+        """Extract player's transfer history from API response.
+
+        @url https://www.transfermarkt.co.uk/ceapi/transferHistory/list/246968
+        @returns items 7 7
+        @cb_kwargs {"parent": {"type": "player", "href": "/ayoze-perez/profil/spieler/246968"}}
+        @scrapes type href parent season date from to market_value fee
+        """
+
+        data = json.loads(response.text)
+
+        for transfer in data['transfers']:
+            yield {
+                'type': 'transfer',
+                'href': transfer['url'],
+                'parent': parent,
+                'season': transfer['season'],
+                'date': transfer['dateUnformatted'],
+                'from': {
+                    'name': transfer['from']['clubName'],
+                    'url': transfer['from']['href']
+                },
+                'to': {
+                    'name': transfer['to']['clubName'],
+                    'url': transfer['to']['href']
+                },
+                'market_value': transfer['marketValue'],
+                'fee': transfer['fee']
+            }


### PR DESCRIPTION
# Add PlayerTransfersSpider for scraping transfer data

## Description
This pull request introduces a new spider, `PlayerTransfersSpider`, designed to scrape transfer history data for football players from transfermarkt.co.uk. The spider utilizes Scrapy framework and follows the structure of our BaseSpider class.

## Features
- Parses player profile pages to extract transfer history API URL
- Makes API calls to retrieve detailed transfer data
- Extracts key information including transfer dates, clubs involved, market values, and transfer fees

## Implementation Details
- Uses JSON parsing to handle API responses
- Implements two main parsing methods: `parse` and `parse_transfers`
- Includes Scrapy contracts for testing and documentation purposes

Please review and provide feedback, especially regarding the structure and any potential optimizations.